### PR TITLE
Clean responsive breakpoints for Timeline items

### DIFF
--- a/1960s.html
+++ b/1960s.html
@@ -17,7 +17,7 @@ title: timeline
 								</p>
 							</div>
 							</div>
-							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330"/>
+							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380"/>
 						</li>
 						<li class="timeline-event__item">
 							<div class="timeline-event__item-info">
@@ -28,7 +28,7 @@ title: timeline
 								</p>
 							</div>
 							</div>
-							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330"/>
+							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380"/>
 						</li>
 						<li class="timeline-event__item">
 							<div class="timeline-event__item-info">
@@ -39,7 +39,7 @@ title: timeline
 								<p>Phase I of construction of the permanent facility was completed in 1972. Phase II was finished a year later. Between them, they include a three-story main building, two-story vocational building, more than 60 classrooms and laboratories, a bookstore, college center, auditorium, offices and library (then called “Learning Resource center”).</p>
 							</div>
 							</div>
-							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330"/>
+							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380"/>
 						</li>
 						<li class="timeline-event__item">
 							<div class="timeline-event__item-info">
@@ -49,7 +49,7 @@ title: timeline
 								<p>It’s official: the college is a hit. When the doors opened, 563 students were enrolled in 30 credit classes. The continuing education area dwarfed the credit, with 1,305 students registered for 139 adult continuing education classes. The College had an original faculty team of 13 instructors.</p>
 							</div>
 							</div>
-							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330"/>
+							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380"/>
 						</li>
 						<li class="timeline-event__item">
 							<div class="timeline-event__item-info">
@@ -59,7 +59,7 @@ title: timeline
 								<p>The Board of Trustees passed a resolution establishing the KCC Foundation to provide financial and other support for the college and its activities. It is established as the sole official fund raising and private gift-receiving agency for the college. The first donation was $60, and it was made by Donald Zeglis, who served as KCC’s legal counsel. For the last 47 years, the Foundation has managed the distribution of scholarship awards, assisted with the establishment of gifts and administered planned giving programs through trusts and wills. Today, more than $200,000 in scholarships is awarded to KCC students annually and the Foundation’s current assets are $5.6 million. The Foundation funds scholarships and grants to assist students. They also support student clubs and fund some college equipment purchases. Through gifts from KCC employees, the Foundation also provides some student success initiatives.</p>
 							</div>
 							</div>
-							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330"/>
+							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380"/>
 						</li>
 					</ul>
 

--- a/1970s.html
+++ b/1970s.html
@@ -17,7 +17,7 @@ title: timeline
 								</p>
 							</div>
 							</div>
-								<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330"/>
+								<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380"/>
 							</li>
 						</li>
 						<li class="timeline-event__item">
@@ -29,7 +29,7 @@ title: timeline
 								</p>
 							</div>
 							</div>
-							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330"/>
+							<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380"/>
 						</li>
 						<li class="timeline-event__item">
 							<div class="timeline-event__item-info">
@@ -40,7 +40,7 @@ title: timeline
 								</p>
 							</div>
 							</div>
-								<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330"/>
+								<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380"/>
 						</li>
 						<li class="timeline-event__item">
 							<div class="timeline-event__item-info">
@@ -51,7 +51,7 @@ title: timeline
 								</p>
 							</div>
 							</div>
-								<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330"/>
+								<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380"/>
 						</li>
 						<li class="timeline-event__item">
 							<div class="timeline-event__item-info">
@@ -64,18 +64,18 @@ title: timeline
 								</p>
 							</div>
 							</div>
-								<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330"/>
+								<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380"/>
 						</li>
 						<li class="timeline-event__item">
 							<div class="timeline-event__item-info">
 							<h1 class="timeline-event__date">Sept. 24, 1978</h1>
 							<h2 class="timeline-event__title">Skylark sculpture dedicated</h2>
 							<div class="timeline-event__description">
-								<p>It was Illinois Arts week and days before KCC’s 10th Anniversary when Skylark—KCC’s first sculpture—was dedicated to the college’s first board of trustees: Ralph Francis, Mary Fraser, James Geist, Merlin Karlock, John Rooney, Kenneth Seebach & Kenneth Wiser. The $3,000 cost was funded through a bequest left to the college by William F. Brandenburg and the Illinois Arts Council. The artist, Alice Richheimer Culbert Wolk lived in Glencoe at the time the work was purchased. After being completed in 1977, the 8 foot, 6 inch tall "Skylark" was mounted in July, 1978. Made of corten steel, and weighing 800 pounds, Skylark was originally on KCC’s front lawn. It had at least one other roost before being moved in 2014 to be alongside the college’s main drive. At the dedication in 1978, Dr. Janet Heinicke, head of the visual arts program, described the piece: “The skylark bird is an appropriate educational symbol. In literature, the skylark is referred to as a soaring bird with distinct, if not loud, voice. Chaucer called it the messenger of the day. Elizabeth Barrett Browning noted 'soaring music within the soaring lark.' "In light of education, such images conjure thoughts of lofty, bold, clear and fresh ideas that prosper in educational institutions of a democracy and give us insight into ourselves and our world. Skylark, distinguished by its curves that give an impression of infinity, and its contrasting earthborn foundation, connotes two characteristics of the public community college. One, a continuum of thought and intellect reminiscent of the skylark bird and, two, an institution whose roots are firmly embedded in the land and the people of the land known as the community college district." Other notes from the day of dedication included this: “skylark--a bird of flight whose voice is a special cry and considered something beautiful. The sculpture’s abstract lines are infinite and open curves. Part of the educational process is not knowing where the end is--or it’s a never ending process. The result is not immediately visible. The sculpture’s bottom line is earth-bound. A public community college is very much related to its constituency. Urban and rural community are tied to the earth." The college now has three other permanent outdoor sculptures, Chicago Nike, Meridian IX, and Tin Man. The Arts and Culture site has more information about them, and about indoor sculpture at KCC.
+								<p>It was Illinois Arts week and days before KCC’s 10th Anniversary when Skylark—KCC’s first sculpture—was dedicated to the college’s first board of trustees: Ralph Francis, Mary Fraser, James Geist, Merlin Karlock, John Rooney, Kenneth Seebach &amp; Kenneth Wiser. The $3,000 cost was funded through a bequest left to the college by William F. Brandenburg and the Illinois Arts Council. The artist, Alice Richheimer Culbert Wolk lived in Glencoe at the time the work was purchased. After being completed in 1977, the 8 foot, 6 inch tall "Skylark" was mounted in July, 1978. Made of corten steel, and weighing 800 pounds, Skylark was originally on KCC’s front lawn. It had at least one other roost before being moved in 2014 to be alongside the college’s main drive. At the dedication in 1978, Dr. Janet Heinicke, head of the visual arts program, described the piece: “The skylark bird is an appropriate educational symbol. In literature, the skylark is referred to as a soaring bird with distinct, if not loud, voice. Chaucer called it the messenger of the day. Elizabeth Barrett Browning noted 'soaring music within the soaring lark.' "In light of education, such images conjure thoughts of lofty, bold, clear and fresh ideas that prosper in educational institutions of a democracy and give us insight into ourselves and our world. Skylark, distinguished by its curves that give an impression of infinity, and its contrasting earthborn foundation, connotes two characteristics of the public community college. One, a continuum of thought and intellect reminiscent of the skylark bird and, two, an institution whose roots are firmly embedded in the land and the people of the land known as the community college district." Other notes from the day of dedication included this: “skylark--a bird of flight whose voice is a special cry and considered something beautiful. The sculpture’s abstract lines are infinite and open curves. Part of the educational process is not knowing where the end is--or it’s a never ending process. The result is not immediately visible. The sculpture’s bottom line is earth-bound. A public community college is very much related to its constituency. Urban and rural community are tied to the earth." The college now has three other permanent outdoor sculptures, Chicago Nike, Meridian IX, and Tin Man. The Arts and Culture site has more information about them, and about indoor sculpture at KCC.
 								</p>
 							</div>
 							</div>
-								<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330"/>
+								<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380"/>
 						</li>
 					</ul>
 

--- a/1980s.html
+++ b/1980s.html
@@ -17,7 +17,7 @@ title: timeline
 								</p>
 							</div>
 						</div>
-						<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330" />
+						<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380" />
 					</li>
 				</ul>
 			</section>

--- a/1990s.html
+++ b/1990s.html
@@ -17,7 +17,7 @@ title: timeline
 								</p>
 							</div>
 						</div>
-						<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330" />
+						<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380" />
 					</li>
 				</ul>
 			</section>

--- a/2000s.html
+++ b/2000s.html
@@ -17,7 +17,7 @@ title: timeline
 								</p>
 							</div>
 						</div>
-						<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330" />
+						<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380" />
 					</li>
 				</ul>
 			</section>

--- a/2010s.html
+++ b/2010s.html
@@ -17,7 +17,7 @@ title: timeline
 								</p>
 							</div>
 						</div>
-						<img class="timeline-event__photo" src="/assets/img/dummy.png" width="360" height="330" />
+						<img class="timeline-event__photo" src="/assets/img/dummy.png" width="300" height="380" />
 					</li>
 				</ul>
 			</section>

--- a/assets/css/4-pages/_decades.scss
+++ b/assets/css/4-pages/_decades.scss
@@ -3,7 +3,7 @@
 }
 .decade {
   background-color: $primary-red;
-  padding:20px 0 20px 40px;
+  padding: 20px 0 20px 40px;
 }
 .decade-year {
   color: $white;
@@ -22,8 +22,8 @@
 .timeline-event__date {
   color: $primary-blue;
   font-size: 43px;
-  margin-top: 0;
   margin-bottom: 5px;
+  margin-top: 0;
 }
 .timeline-event__title {
   color: $primary-red;
@@ -32,8 +32,8 @@
   margin-bottom: 0.1em;
 }
 .timeline-event__description {
-  font-size: 18px;
   color: $primary-blue;
+  font-size: 18px;
   font-weight: 400;
 }
 
@@ -44,11 +44,20 @@
   margin-left: 10px;
 }
 
-@media(max-width:767px){
+@media(max-width:767px) {
+
+  .decade {
+    padding-left: 20px;
+  }
+
+  .timeline-event__group {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
   .timeline-event__item {
     flex-direction: column;
     margin-left: 0;
-    margin-right: 20px;
+    margin-right: 0;
     width: auto;
   }
 
@@ -57,6 +66,7 @@
   }
 
   .timeline-event__photo {
-    margin-left: 10px;
+    margin-left: 0;
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
I made the images in decade pages 300 wide by 330 high. This is just
cosmetic and will be adjusted later.